### PR TITLE
[feature] Add subcategories to csv export

### DIFF
--- a/app/imports/ui/lexes/List.jsx
+++ b/app/imports/ui/lexes/List.jsx
@@ -85,6 +85,23 @@ class List extends Component {
       let category = Categories.findOne({ _id: lex.categoryId });
       lex.categoryNameFr = category.nameFr;
       lex.categoryNameEn = category.nameEn;
+
+      // Subcategories info
+      lexes.forEach(function (lex) {
+          let resultFr = "";
+          let resultEn = "";
+          for (let subcategory of lex.subcategories) {
+            resultFr += subcategory.nameFr
+            resultEn += subcategory.nameEn
+            if (lex.subcategories.length -1 !== lex.subcategories.indexOf(subcategory)) {
+              resultFr += "|"
+              resultEn += "|"
+            }
+          }
+          lex.subcategoriesFr = resultFr;
+          lex.subcategoriesEn = resultEn;
+      });
+        
     });
     const csv = Papa.unparse({
       // Define fields to export
@@ -103,6 +120,8 @@ class List extends Component {
         "responsibleUrlEn",
         "categoryNameFr",
         "categoryNameEn",
+        "subcategoriesFr",
+        "subcategoriesEn"
       ],
       data: lexes,
     });

--- a/app/server/import-data.js
+++ b/app/server/import-data.js
@@ -62,7 +62,15 @@ updateRoles = () => {
 };
 
 importData = () => {
-  updateRoles();
+  let lexes = Lexes.find({});
+  lexes.forEach((lex) => {
+    if ( ! ("subcategories" in lex)) {  
+      Lexes.update(
+        { _id: lex._id },
+        { $set: { subcategories: [] } }
+      );
+    } 
+  });
 };
 
 export { deleteAll, importData };

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -13,7 +13,7 @@ import "../imports/api/methods/subcategories";
 import "../imports/api/methods/lexes";
 
 Meteor.startup(() => {
-  let needImportData = false;
+  let needImportData = true;
   let activeTequila = true;
 
   // Define lang <html lang="fr" />


### PR DESCRIPTION
Cette PR a pour but d'ajouter les sous-categories dans l'export csv

![image](https://user-images.githubusercontent.com/4997224/102600360-ffb7ec00-411e-11eb-8d20-6f222f437edb.png)

Si il y a plusieurs sous-catégories, elles seront séparées par un pipe | (pas par une virgule car le libellé d'une sous catégorie peut en contenir une).

Pour cette PR il y a une migration des données nécessaires car certaines LEXES n'avaient pas de subcategories.

