### PR TITLE
[feature] Lex redirect

### DIFF
--- a/app/imports/ui/header/Header.jsx
+++ b/app/imports/ui/header/Header.jsx
@@ -45,7 +45,7 @@ const Header = (props) => {
               { isAdmin ?
                 <>
                   <NavLink className="{({isActive}) => (isActive ? 'active-style' : '')} dropdown-item" to="/admin/log/list">Voir les logs</NavLink>
-                  <div className="dropdown-item">Polylex - version 1.9.0</div>
+                  <div className="dropdown-item">Polylex - version 1.10.0</div>
                 </>
                 : null}
               </div>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-polylex",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-polylex",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "start": "meteor run",

--- a/app/server/lex-redirect.js
+++ b/app/server/lex-redirect.js
@@ -1,0 +1,48 @@
+import {
+  Lexes
+} from "../imports/api/collections.js"
+
+// Global API configuration
+let LexRedirect = new Restivus({
+  apiPath: '/lex',
+  useDefaultAuth: false
+});
+
+// Maps to:
+// - /lex/:id, e.g. https://polylex-admin.epfl.ch/lex/1.0.1
+LexRedirect.addRoute(
+  ":id", {
+    authRequired: false
+  }, {
+    get: function() {
+      let lex = Lexes.findOne({ // Let's assume the lex is not abrogated
+        isAbrogated: false,
+        lex: this.urlParams.id
+      }) ?? Lexes.findOne({ // If no lex found, let's try with an abrogated one
+        isAbrogated: true,
+        lex: this.urlParams.id
+      })
+
+      if (lex && lex.urlFr) {
+        return {
+          statusCode: 302,
+          headers: {
+            'Content-Type': 'text/plain',
+            'Location': lex.urlFr
+          },
+          body: `Location: ${lex.urlFr}`
+        }
+      }
+
+      return {
+        statusCode: 404,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+        body: 'Lex not found!'
+      }
+    }
+  }
+)
+
+export default LexRedirect;

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -7,6 +7,7 @@ import { AppLogger } from "../imports/api/logger";
 import { loadFixtures } from "./fixtures";
 import "../imports/api/publications";
 import "./rest-api";
+import "./lex-redirect";
 import "../imports/api/methods/responsibles";
 import "../imports/api/methods/categories";
 import "../imports/api/methods/subcategories";


### PR DESCRIPTION
This add a redirect feature to polylex-admin.epfl.ch: the path `/lex` will now redirect to any french PDF document. For example, https://polylex-admin.epfl.ch/lex/1.0.0 will redirect to the  corresponding document.

By default, it's assumed the the non-abrogated document is called, but  if
it doesn't exist then the abrogated document will be served.

Bump to v1.10.0.